### PR TITLE
fix: option host is unused

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ const parseArgs = () => {
 (async () => {
     const options = parseArgs();
     const client = new Client({
+        host: options.host,
         port: options.port,
         username: options.username,
         password: options.password,


### PR DESCRIPTION
Although `--host` can be specified, the input is not used. This fixes the missing parameter.